### PR TITLE
Fix mobile navigation menu

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -284,9 +284,10 @@ export default function Header() {
         @media (max-width: 768px) {
           .nav-menu {
             position: fixed;
-            top: 100%;
+            top: 0;
             left: 0;
             right: 0;
+            height: 100vh;
             flex-direction: column;
             gap: 0;
             width: 100%;
@@ -302,7 +303,7 @@ export default function Header() {
           }
 
           .nav-menu-open {
-            max-height: 300px;
+            max-height: 100vh;
             padding: 1rem 0;
           }
 


### PR DESCRIPTION
## Summary
- fix nav menu position so it displays on mobile
- ensure nav menu height spans entire viewport

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68640eeb4b70832ab9d118f4a3457e9a